### PR TITLE
Add Slash GraphQL example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you want something that persists in localstorage, you can use `useTodosLocalS
 
 ## List of Implementations
 
+- [Slash GraphQL](https://dgraph.io/slash-graphql): example [repo](https://github.com/dgraph-io/tudo-tutorial) & [blog](https://dgraph.io/blog/post/todo-slash-graphql/)
 - AWS Amplify + AppSync: *tbd*
 - Firebase: *tbd*
 - Netlify + FaunaDB: *tbd*


### PR DESCRIPTION
Thanks for the cool component.  I used it for a blog https://dgraph.io/blog/post/todo-slash-graphql/ (source here https://github.com/dgraph-io/tudo-tutorial) about our hosted GraphQL product.

This PR just references that in the 'implementations' section of the readme.